### PR TITLE
Use 2021 edition to use cargo's new feature resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "yos"         # or any other name
 version = "0.1.0"
+edition = "2021"
 
 [build-dependencies]
 bootloader = "0.11"


### PR DESCRIPTION
Otherwise the crate features are unified across targets. This leads to compile errors since when these optional features depend on the standard library, which is not available for bare metal targets.

See https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#cargos-new-feature-resolver for more info.

Fixes https://github.com/rust-osdev/bootloader/issues/353#issuecomment-1478770705